### PR TITLE
added trigger for no hello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 #secrets file
 .secret
+
+# Jetbrains
+.idea

--- a/bot.py
+++ b/bot.py
@@ -31,6 +31,8 @@ async def no_hello(message):
     msg = lower_message.split(' ')
     if len(msg) == 1 and msg[0] == 'hello':
         await message.channel.send('https://nohello.net/en/')
+        for char in ['N', 'O']:
+            await message.add_reaction(lookup(f'REGIONAL INDICATOR SYMBOL LETTER {char}'))
 
 
 d = dispatcher()

--- a/bot.py
+++ b/bot.py
@@ -5,10 +5,12 @@ import sys
 from unicodedata import lookup
 import string
 
+
 async def add_react(message,name):
     reaction = discord.utils.get(message.guild.emojis,name=name)
     if reaction:
         await message.add_reaction(reaction)
+
 
 async def add_funny_letters(message, text):
     upper_text = text.upper()
@@ -17,10 +19,19 @@ async def add_funny_letters(message, text):
     for char in upper_text: 
         await message.add_reaction(lookup(f'REGIONAL INDICATOR SYMBOL LETTER {char}'))
 
+
 async def gottem_replies(message):
     for word in message.content.split(' '):
         if word.endswith('ma'):
             await message.channel.send(word + ' ' + random.choice(['balls','dick','nuts'])+'! :gottem:')
+
+
+async def no_hello(message):
+    lower_message = message.lower()
+    msg = lower_message.split(' ')
+    if len(msg) == 1 and msg[0] == 'hello':
+        await message.channel.send('https://nohello.net/en/')
+
 
 d = dispatcher()
 d.register_builtin('!ping', lambda msg: msg.channel.send('pong'))
@@ -34,6 +45,8 @@ d.register_cmd('.*(?i)socks.*',lambda msg: add_react(msg,'bonk'),channels = ['^(
 d.register_cmd('.*(?i)js.*', lambda msg: add_funny_letters(msg, 'bad'))
 d.register_cmd('.*(?i)ma\\b.*', gottem_replies)
 d.register_cmd('.*(?i)socks.*',lambda msg: add_react(msg,'nice'),channels = ['programming-socks-gone-wild'])
+d.register_cmd('^[H|h][E|e][L|l][L|l][O|o]$', no_hello)
+
 
 class MyClient(discord.Client):
     async def on_ready(self):
@@ -43,6 +56,7 @@ class MyClient(discord.Client):
         if message.author == self.user:
             return
         await d.dispatch_cmd(message)
+
 
 intents = discord.Intents.default()
 intents.message_content = True


### PR DESCRIPTION
Added a trigger for messages only containing the string "Hello". Should only trigger when "Hello" is the only word in the message and return a link to `https://nohello.net/en/`. Regex trigger should also be case-insensitive.